### PR TITLE
Worked on checkmark 2 of pr #424, some fix up of scattering3d test class

### DIFF
--- a/kymatio/scattering3d/frontend/torch_frontend.py
+++ b/kymatio/scattering3d/frontend/torch_frontend.py
@@ -14,7 +14,7 @@ from ...frontend.torch_frontend import ScatteringTorch
 
 
 import torch
-from .filter_bank import solid_harmonic_filter_bank, gaussian_filter_bank
+from kymatio.scattering3d.filter_bank import solid_harmonic_filter_bank, gaussian_filter_bank
 
 from kymatio.scattering3d.core.scattering3d import scattering3d
 

--- a/kymatio/scattering3d/tests/test_torch_scattering3d.py
+++ b/kymatio/scattering3d/tests/test_torch_scattering3d.py
@@ -2,10 +2,10 @@
 import torch
 import os
 import numpy as np
-
+import pytest
 from kymatio import HarmonicScattering3D
 from kymatio.scattering3d import backend
-from kymatio.scattering3d.utils import generate_weighted_sum_of_gaussians, compute_integrals
+from kymatio.scattering3d.utils import generate_weighted_sum_of_gaussians
 
 
 backends = []
@@ -14,13 +14,13 @@ try:
     if torch.cuda.is_available():
         from skcuda import cublas
         import cupy
-        from kymatio.scattering1d.backend.torch_skcuda_backend import backend
+        from kymatio.scattering3d.backend.torch_skcuda_backend import backend
         backends.append(backend)
 except:
     pass
 
 try:
-    from kymatio.scattering1d.backend.torch_backend import backend
+    from kymatio.scattering3d.backend.torch_backend import backend
     backends.append(backend)
 except:
     pass
@@ -51,7 +51,7 @@ def test_FFT3d_central_freq_batch(device, backend):
 
 @pytest.mark.parametrize("device", devices)
 @pytest.mark.parametrize("backend", backends)
-def test_fft3d_error():
+def test_fft3d_error(backend, device):
     x = torch.zeros(8, 1)
     with pytest.raises(TypeError) as record:
         backend.fft(x)
@@ -182,7 +182,7 @@ def test_against_standard_computations(device, backend):
 
 
 
-    order_0 = compute_integrals(x, integral_powers)
+    order_0 = backend.compute_integrals(x, integral_powers)
     scattering.max_order = 2
     scattering.method = 'integral'
     scattering.integral_powers = integral_powers
@@ -269,7 +269,7 @@ def test_larger_scales(device, backend):
 
 @pytest.mark.parametrize("device", devices)
 @pytest.mark.parametrize("backend", backends)
-def test_scattering_methods():
+def test_scattering_methods(device, backend):
     shape = (32, 32, 32)
     J = 4
     L = 3

--- a/kymatio/scattering3d/utils.py
+++ b/kymatio/scattering3d/utils.py
@@ -50,39 +50,6 @@ def generate_weighted_sum_of_gaussians(grid, positions, weights, sigma,
                         (grid[2] - center[2]) ** 2) / sigma**2)
     return signals / ((2 * np.pi) ** 1.5 * sigma ** 3)
 
-
-def subsample(input_array, j):
-    return input_array[..., ::2 ** j, ::2 ** j, ::2 ** j, :].contiguous()
-
-
-
-def compute_integrals(input_array, integral_powers):
-    """
-        Computes integrals of the input_array to the given powers.
-
-        Parameters
-        ----------
-        input_array: torch tensor
-            size (B, M, N, O), B batch_size, M, N, O spatial dims
-
-        integral_powers: list
-            list of P positive floats containing the p values used to
-            compute the integrals of the input_array to the power p (l_p norms)
-
-        Returns
-        -------
-        integrals: torch tensor
-            tensor of size (B, P) containing the integrals of the input_array
-            to the powers p (l_p norms)
-
-    """
-    integrals = torch.zeros(input_array.size(0), len(integral_powers), 1)
-    for i_q, q in enumerate(integral_powers):
-        integrals[:, i_q, 0] = (input_array ** q).view(
-                                        input_array.size(0), -1).sum(1).cpu()
-    return integrals
-
-
 def get_3d_angles(cartesian_grid):
     """
         Given a cartesian grid, computes the spherical coord angles (theta, phi).


### PR DESCRIPTION
Hi Dr. Oyallon,

hope you do not mind me contributing. In this pull request I worked on the 2nd checkmark of PR #424, namely I moved subsample and compute_integrals from utils to backend/torch_backend, and made the appropriate changes to backend to accommodate the aforementioned functions. 

One thing I noticed in your refactor of the code is that subsample does not appear to be used anymore. Am I correct? Should I just remove subsample from backend then?

On another note, I made some minor modifications to the scattering3d test file.  Originally, on my system, none of the tests in the test file worked due to an import error for compute_integrals. Currently the pytest file just skips through all the tests. 

